### PR TITLE
Add option to prevent multiple connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The `speaker-agent.py` python script, also shown below, will set the Raspberry P
 #!/usr/bin/python3
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import argparse
 import dbus
 import dbus.service
 import dbus.mainloop.glib
@@ -59,7 +60,38 @@ class Rejected(dbus.DBusException):
 
 
 class Agent(dbus.service.Object):
-    exit_on_release = True
+
+    def __init__(self, bus, path, single_connection):
+        self.exit_on_release = True
+        self.remote_device = None
+
+        dbus.service.Object.__init__(self, bus, path)
+
+        if single_connection:
+            bus.add_signal_receiver(self.signal_handler,
+                                    bus_name='org.bluez',
+                                    interface_keyword='org.freedesktop.DBus.Properties',
+                                    member_keyword='PropertiesChanged',
+                                    arg0='org.bluez.Device1',
+                                    path_keyword='path'
+                                    )
+
+    def signal_handler(self, *args, **kwargs):
+        path = kwargs['path']
+        connected = None
+        for i, arg in enumerate(args):
+            if type(arg) == dbus.Dictionary and "Connected" in arg:
+                connected = arg["Connected"]
+
+        if connected == None:
+            return
+
+        if not self.remote_device and connected == True:
+            self.remote_device = path
+            print("{} connected".format(path))
+        elif path == self.remote_device and connected == False:
+            self.remote_device = None
+            print("{} disconnected".format(path))
 
     def set_exit_on_release(self, exit_on_release):
         self.exit_on_release = exit_on_release
@@ -74,6 +106,10 @@ class Agent(dbus.service.Object):
     @dbus.service.method(AGENT_INTERFACE,
                          in_signature="os", out_signature="")
     def AuthorizeService(self, device, uuid):
+        if self.remote_device and self.remote_device != device:
+            print("%s try to connect while %s already connected" % (device, self.remote_device))
+            raise Rejected("Connection rejected by user")
+
         # Always authorize A2DP and AVRCP connection
         if uuid in [A2DP, AVRCP]:
             print("AuthorizeService (%s, %s)" % (device, uuid))
@@ -117,11 +153,15 @@ def nameownerchanged_handler(*args, **kwargs):
 
 
 if __name__ == '__main__':
+    options = argparse.ArgumentParser(description="BlueZ Speaker Agent")
+    options.add_argument("--single-connection", action='store_true', help="Allow only one connection at a time")
+    args = options.parse_args()
+
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
     bus = dbus.SystemBus()
 
-    agent = Agent(bus, AGENT_PATH)
+    agent = Agent(bus, AGENT_PATH, args.single_connection)
     agent.set_exit_on_release(False)
 
     bus.add_signal_receiver(nameownerchanged_handler,
@@ -154,6 +194,11 @@ ExecStart=python speaker-agent.py
 [Install]
 WantedBy=default.target
 ```
+
+By default multiple devices can connect to the speaker and the audio of them are mixed.
+
+If you want to prevent this behavior, the speaker agent daemon support the `--single-connection` option.
+To use it replace `ExecStart=python speaker-agent.py` by `ExecStart=python speaker-agent.py --single-connection` in the systemd unit file.
 
 This systemd unit will need to be placed in `~/.config/systemd/user/` and enabled manually using:
 ```


### PR DESCRIPTION
By default multiple devices can connect to the speaker and the audio of them are mixed.

To prevent this behavior, the speaker agent daemon support the `--single-connection` option.  
To use it replace `ExecStart=python speaker-agent.py` by `ExecStart=python speaker-agent.py --single-connection` in the systemd unit file.

In this case the user agent will track the devices connection/disconnection and reject A2DP service connection if another device is already connected.

Fixes #2